### PR TITLE
Set default port

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const app = require("./server");
 
-const { PORT } = process.env;
+const { PORT = 3000 } = process.env;
 
 app.listen(PORT, () => {
   console.info(`Truework.js demo server running on http://localhost:${PORT}\n`);


### PR DESCRIPTION
**Problem**

We require the user to set a `PORT` environment variable, but that isn't mentioned anywhere. This means that the server doesn't bind to any port at all,  and outputs:

```
Truework.js demo server running on http://localhost/:undefined
```

**Solution**

Use the default port `3000`.