### PR TITLE
Set HTML document language

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
 


### PR DESCRIPTION
**Problem**

Opening the demo in chrome triggers the Translate feature, because Chrome thinks that the document is written in Dutch (for one reason or another). This is a confusing experience for users.

**Solution**

Set the HTML document language to English.